### PR TITLE
fix: change python version to 3.8

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,4 +11,4 @@
 oneidentity-safeguard-sessions-plugin-sdk = "~=1.1.0"
 
 [requires]
-python_version = "3.6"
+python_version = "3.8"


### PR DESCRIPTION
We change plugin Pipfile python required version to 3.8
because our plugin-sdk now runs with python 3.8

Signed-off-by: Bence Gaspar <bence.gaspar@balabit.com>