### PR TITLE
feature: for ease of use with SRA turn off asking for fake pwd by default

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -1,7 +1,7 @@
 [skeleton]
 
 # To enable or disable asking for MFA password, configure 'ask_pass'.
-; ask_pass=yes
+; ask_pass=no
 
 #
 # The follow comes from the Plugin SDK documentation on

--- a/plugin/plugin_bare.py
+++ b/plugin/plugin_bare.py
@@ -25,7 +25,7 @@ from safeguard.sessions.plugin import AAPlugin, AAResponse
 class Plugin(AAPlugin):
 
     def _extract_mfa_password(self):
-        if self.plugin_configuration.getboolean("skeleton", "ask_pass", default=True):
+        if self.plugin_configuration.getboolean("skeleton", "ask_pass", default=False):
             return super()._extract_mfa_password()
         else:
             return 'can pass'


### PR DESCRIPTION
People don't read the documentation so it's easier to release the
plugin this way.

Signed-off-by: Gyorgy Krajcsovits <gyorgy.krajcsovits@oneidentity.com>